### PR TITLE
Feature: [resolves #202] add element-wise iteration via IntoElementIterator + Elements

### DIFF
--- a/intervalsets-core/src/ops/elem_iter.rs
+++ b/intervalsets-core/src/ops/elem_iter.rs
@@ -319,6 +319,20 @@ impl<T: Element + Ord> Iterator for DisjointElements<T> {
         }
         None
     }
+
+    // Delegate to the at-most-two children. Today both contribute
+    // (0, None), so this matches the default — but when Elements gains
+    // a tighter hint (via Countable, deferred), we pick it up for free.
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (fl, fu) = self.front.as_ref().map_or((0, Some(0)), Iterator::size_hint);
+        let (bl, bu) = self.back.as_ref().map_or((0, Some(0)), Iterator::size_hint);
+        let lower = fl.saturating_add(bl);
+        let upper = match (fu, bu) {
+            (Some(a), Some(b)) => a.checked_add(b),
+            _ => None,
+        };
+        (lower, upper)
+    }
 }
 
 impl<T: Element + Ord> DoubleEndedIterator for DisjointElements<T> {
@@ -610,5 +624,13 @@ mod tests {
         )
             .into();
         assert!(pair.into_elements().eq([0u8, 1, 254, 255]));
+    }
+
+    #[test]
+    fn disjoint_elements_size_hint_consumed_is_exact_zero() {
+        // With both cursors None, the delegated hint reports the
+        // tightest possible (0, Some(0)) rather than (0, None).
+        let it = MaybeDisjoint::<i32>::Consumed.into_elements();
+        assert_eq!(it.size_hint(), (0, Some(0)));
     }
 }

--- a/intervalsets-core/src/ops/elem_iter.rs
+++ b/intervalsets-core/src/ops/elem_iter.rs
@@ -113,7 +113,6 @@ pub struct Elements<T> {
 }
 
 impl<T> Elements<T> {
-    #[inline(always)]
     const fn empty() -> Self {
         Self { front: None, back: None }
     }
@@ -164,12 +163,10 @@ impl<T: Element + Ord> Iterator for Elements<T> {
         Some(current)
     }
 
-    // size_hint defaults to (0, None). A tighter bound for finite-bounded
-    // intervals is `Countable::count_inclusive(front, back)`, which would
-    // also unlock ExactSizeIterator. Deferred: pulling Countable into
-    // these bounds shrinks the set of types this works for. Revisit as a
-    // separate `impl<T: Countable> Elements<T>` block carrying only the
-    // tighter size_hint and ExactSizeIterator.
+    // Default size_hint of (0, None) is intentional: a tighter bound
+    // requires `Countable`, which we keep off the type bounds. Revisit
+    // as a separate `impl<T: Countable> Elements<T>` adding both
+    // size_hint and ExactSizeIterator.
 }
 
 impl<T: Element + Ord> DoubleEndedIterator for Elements<T> {

--- a/intervalsets-core/src/ops/elem_iter.rs
+++ b/intervalsets-core/src/ops/elem_iter.rs
@@ -1,9 +1,11 @@
-//! Iterate the discrete element values of an interval.
+//! Iterate the discrete element values of an interval or disjoint pair.
 //!
 //! [`IntoElementIterator`] is the trait entry point: any owned set type
-//! that knows how to enumerate its elements implements it. The companion
-//! [`Elements`] iterator does the per-step walk via
-//! [`Element::try_adjacent`](crate::numeric::Element::try_adjacent).
+//! that knows how to enumerate its elements implements it. [`Elements`]
+//! does the per-step walk over a single interval via
+//! [`Element::try_adjacent`](crate::numeric::Element::try_adjacent), and
+//! [`DisjointElements`] composes it across the at-most-two pieces of a
+//! [`MaybeDisjoint`](crate::disjoint::MaybeDisjoint).
 //!
 //! # Why not [`IntoIterator`]?
 //!
@@ -42,6 +44,7 @@
 //! tier model.
 
 use crate::bound::{BoundType, FiniteBound, Side};
+use crate::disjoint::MaybeDisjoint;
 use crate::numeric::Element;
 use crate::sets::{EnumInterval, FiniteInterval, HalfInterval};
 
@@ -266,6 +269,117 @@ impl<T: Element + Ord + Clone> EnumInterval<T> {
     }
 }
 
+// ---- MaybeDisjoint ----
+
+/// Iterator over the discrete element values of a [`MaybeDisjoint`].
+///
+/// `MaybeDisjoint` is at most two pieces, so this iterator holds at most
+/// two `Elements<T>` walkers — one per cursor. Implements [`Iterator`],
+/// [`DoubleEndedIterator`], and [`core::iter::FusedIterator`].
+///
+/// Constructed via [`IntoElementIterator::into_elements`] (consume) or
+/// [`MaybeDisjoint::elements`] (borrow).
+///
+/// # Examples
+///
+/// ```
+/// use intervalsets_core::prelude::*;
+/// use intervalsets_core::disjoint::MaybeDisjoint;
+///
+/// let lhs = EnumInterval::closed(0, 2);
+/// let rhs = EnumInterval::closed(10, 12);
+/// let pair: MaybeDisjoint<i32> = (lhs, rhs).into();
+///
+/// let xs: Vec<i32> = pair.into_elements().collect();
+/// assert_eq!(xs, vec![0, 1, 2, 10, 11, 12]);
+/// ```
+pub struct DisjointElements<T> {
+    front: Option<Elements<T>>,
+    back: Option<Elements<T>>,
+}
+
+impl<T: Element + Ord> Iterator for DisjointElements<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        if let Some(it) = self.front.as_mut() {
+            if let Some(v) = it.next() {
+                return Some(v);
+            }
+            self.front = None;
+        }
+        // Front exhausted; back walker now owns whatever's left.
+        // Elements<T> is itself DoubleEndedIterator, so meeting in
+        // the middle is handled there.
+        if let Some(it) = self.back.as_mut() {
+            if let Some(v) = it.next() {
+                return Some(v);
+            }
+            self.back = None;
+        }
+        None
+    }
+}
+
+impl<T: Element + Ord> DoubleEndedIterator for DisjointElements<T> {
+    fn next_back(&mut self) -> Option<T> {
+        if let Some(it) = self.back.as_mut() {
+            if let Some(v) = it.next_back() {
+                return Some(v);
+            }
+            self.back = None;
+        }
+        if let Some(it) = self.front.as_mut() {
+            if let Some(v) = it.next_back() {
+                return Some(v);
+            }
+            self.front = None;
+        }
+        None
+    }
+}
+
+impl<T: Element + Ord> core::iter::FusedIterator for DisjointElements<T> {}
+
+impl<T: Element + Ord> IntoElementIterator for MaybeDisjoint<T> {
+    type Item = T;
+    type IntoIter = DisjointElements<T>;
+
+    fn into_elements(self) -> DisjointElements<T> {
+        match self {
+            MaybeDisjoint::Consumed => DisjointElements { front: None, back: None },
+            MaybeDisjoint::Connected(iv) => DisjointElements {
+                front: Some(iv.into_elements()),
+                back: None,
+            },
+            MaybeDisjoint::Disjoint(lhs, rhs) => DisjointElements {
+                front: Some(lhs.into_elements()),
+                back: Some(rhs.into_elements()),
+            },
+        }
+    }
+}
+
+impl<T: Element + Ord + Clone> MaybeDisjoint<T> {
+    /// Borrow `self` and produce an iterator over its discrete elements.
+    ///
+    /// Walks each piece in order, yielding every element along the way.
+    /// The returned iterator is double-ended.
+    pub fn elements(&self) -> DisjointElements<T> {
+        match self {
+            MaybeDisjoint::Consumed => DisjointElements { front: None, back: None },
+            MaybeDisjoint::Connected(iv) => DisjointElements {
+                front: Some(iv.elements()),
+                back: None,
+            },
+            MaybeDisjoint::Disjoint(lhs, rhs) => DisjointElements {
+                front: Some(lhs.elements()),
+                back: Some(rhs.elements()),
+            },
+        }
+    }
+}
+
 /// f32/f64 are not `Ord`, so `into_elements()` doesn't compile for them.
 ///
 /// ```compile_fail
@@ -278,7 +392,7 @@ struct ContinuousCompileFailDoctest;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::factory::FiniteFactory;
+    use crate::factory::{FiniteFactory, HalfBoundedFactory};
 
     #[test]
     fn finite_closed_walks_forward() {
@@ -425,5 +539,76 @@ mod tests {
         assert_eq!(it.next(), None);
         assert_eq!(it.next(), None);
         assert_eq!(it.next_back(), None);
+    }
+
+    // ---- MaybeDisjoint coverage ----
+
+    #[test]
+    fn maybe_disjoint_consumed_yields_nothing() {
+        let mut it = MaybeDisjoint::<i32>::Consumed.into_elements();
+        assert_eq!(it.next(), None);
+        assert_eq!(it.next_back(), None);
+    }
+
+    #[test]
+    fn maybe_disjoint_connected_walks_forward() {
+        let pair = MaybeDisjoint::Connected(EnumInterval::closed(2, 5));
+        assert!(pair.into_elements().eq([2, 3, 4, 5]));
+    }
+
+    #[test]
+    fn maybe_disjoint_connected_walks_backward() {
+        let pair = MaybeDisjoint::Connected(EnumInterval::closed(2, 5));
+        assert!(pair.into_elements().rev().eq([5, 4, 3, 2]));
+    }
+
+    #[test]
+    fn maybe_disjoint_two_pieces_walks_forward() {
+        let pair: MaybeDisjoint<i32> =
+            (EnumInterval::closed(0, 2), EnumInterval::closed(10, 12)).into();
+        assert!(pair.into_elements().eq([0, 1, 2, 10, 11, 12]));
+    }
+
+    #[test]
+    fn maybe_disjoint_two_pieces_walks_backward() {
+        let pair: MaybeDisjoint<i32> =
+            (EnumInterval::closed(0, 2), EnumInterval::closed(10, 12)).into();
+        assert!(pair.into_elements().rev().eq([12, 11, 10, 2, 1, 0]));
+    }
+
+    #[test]
+    fn maybe_disjoint_mixed_walk_meets_inside_one_piece() {
+        let pair: MaybeDisjoint<i32> =
+            (EnumInterval::closed(0, 1), EnumInterval::closed(10, 14)).into();
+        let mut it = pair.into_elements();
+        assert_eq!(it.next(), Some(0));
+        assert_eq!(it.next(), Some(1));
+        assert_eq!(it.next_back(), Some(14));
+        assert_eq!(it.next(), Some(10));
+        assert_eq!(it.next_back(), Some(13));
+        assert_eq!(it.next(), Some(11));
+        assert_eq!(it.next_back(), Some(12));
+        assert_eq!(it.next(), None);
+        assert_eq!(it.next_back(), None);
+    }
+
+    #[test]
+    fn maybe_disjoint_borrowed_does_not_consume() {
+        let pair: MaybeDisjoint<u8> =
+            (EnumInterval::closed(0u8, 1), EnumInterval::closed(10, 11)).into();
+        assert!(pair.elements().eq([0u8, 1, 10, 11]));
+        // Still usable.
+        assert_eq!(pair.elements().count(), 4);
+    }
+
+    #[test]
+    fn maybe_disjoint_with_half_bounded_piece() {
+        // Right piece is `[254, +∞)` over u8 → walks to MAX = 255.
+        let pair: MaybeDisjoint<u8> = (
+            EnumInterval::closed(0u8, 1),
+            EnumInterval::closed_unbound(254),
+        )
+            .into();
+        assert!(pair.into_elements().eq([0u8, 1, 254, 255]));
     }
 }

--- a/intervalsets-core/src/ops/elem_iter.rs
+++ b/intervalsets-core/src/ops/elem_iter.rs
@@ -1,0 +1,432 @@
+//! Iterate the discrete element values of an interval.
+//!
+//! [`IntoElementIterator`] is the trait entry point: any owned set type
+//! that knows how to enumerate its elements implements it. The companion
+//! [`Elements`] iterator does the per-step walk via
+//! [`Element::try_adjacent`](crate::numeric::Element::try_adjacent).
+//!
+//! # Why not [`IntoIterator`]?
+//!
+//! [`IntervalSet`](https://docs.rs/intervalsets/latest/intervalsets/struct.IntervalSet.html)
+//! has two natural iteration semantics — interval-wise (yielding pieces)
+//! and element-wise (yielding `T`). [`IntoIterator`] is reserved for the
+//! interval-wise reading; element-wise iteration uses
+//! [`IntoElementIterator`] so the two don't compete.
+//!
+//! # Why `T: Element + Ord`?
+//!
+//! `Element` brings [`try_adjacent`](crate::numeric::Element::try_adjacent),
+//! which is what advances the cursor. The extra `Ord` bound is the
+//! ecosystem-standard gate that excludes `f32`/`f64` (not `Ord` because of
+//! NaN). Every discrete `Element` impl in this crate is already `Ord`, so
+//! the bound costs nothing in practice. Same per-trait split used by
+//! `Union` and friends.
+//!
+//! # Half-bounded and unbounded shapes
+//!
+//! Each cursor (`front`, `back`) is independently `Option<T>`. A `None`
+//! cursor *is* "this direction yields nothing" — no special-case
+//! branches, no panics, no errors:
+//!
+//! - `[a, +∞)` → `front = Some(a)`, `back = None`. Forward walks until
+//!   `try_adjacent` returns `None` at the type's MAX; reverse yields
+//!   nothing.
+//! - `(-∞, b]` → `front = None`, `back = Some(b)`. Mirror.
+//! - `(-∞, +∞)` → both `None`, both directions yield nothing.
+//! - empty → both `None`.
+//!
+//! # Contract
+//!
+//! Tier 2 (infallible when closed over the invariants). Iteration cannot
+//! panic given a well-formed interval. See [`crate::ops`] for the full
+//! tier model.
+
+use crate::bound::{BoundType, FiniteBound, Side};
+use crate::numeric::Element;
+use crate::sets::{EnumInterval, FiniteInterval, HalfInterval};
+
+/// Convert a set value into an iterator that yields its discrete elements.
+///
+/// Distinct from [`IntoIterator`] so set types can keep `IntoIterator` for
+/// interval-wise iteration without conflict. Implemented only on owned set
+/// types — for borrowed iteration, use the inherent `.elements()` method
+/// on the set type, which mirrors std's `iter()` / `into_iter()`
+/// convention.
+///
+/// # Examples
+///
+/// ```
+/// use intervalsets_core::prelude::*;
+///
+/// let xs: Vec<i32> = EnumInterval::closed(0, 4).into_elements().collect();
+/// assert_eq!(xs, vec![0, 1, 2, 3, 4]);
+///
+/// let xs: Vec<i32> = EnumInterval::closed(0, 4).into_elements().rev().collect();
+/// assert_eq!(xs, vec![4, 3, 2, 1, 0]);
+/// ```
+///
+/// # Contract
+///
+/// Tier 2 (infallible when closed over the invariants). See
+/// [`crate::ops`] for the full tier model.
+pub trait IntoElementIterator {
+    /// The element type produced by the iterator.
+    type Item;
+    /// The iterator type.
+    type IntoIter: Iterator<Item = Self::Item>;
+    /// Consume `self` and return an iterator over its elements.
+    fn into_elements(self) -> Self::IntoIter;
+}
+
+/// Iterator over the discrete element values of an interval.
+///
+/// Yields `T` by value via [`Element::try_adjacent`]. Implements
+/// [`Iterator`], [`DoubleEndedIterator`], and [`core::iter::FusedIterator`],
+/// so combinators like `.rev()`, `.collect()`, `.take_while()`, and
+/// `.fuse()` all work as expected.
+///
+/// Constructed via [`IntoElementIterator::into_elements`] (consume) or the
+/// inherent `.elements()` methods on the interval types (borrow).
+///
+/// # Examples
+///
+/// ```
+/// use intervalsets_core::prelude::*;
+///
+/// // Forward walk over a closed interval.
+/// let xs: Vec<u8> = FiniteInterval::closed(2u8, 5).into_elements().collect();
+/// assert_eq!(xs, vec![2, 3, 4, 5]);
+///
+/// // Open bounds step in for discrete types.
+/// let xs: Vec<i32> = EnumInterval::open(0, 5).into_elements().collect();
+/// assert_eq!(xs, vec![1, 2, 3, 4]);
+///
+/// // Reaching the type's MAX terminates iteration without panicking.
+/// let xs: Vec<u8> = FiniteInterval::closed(u8::MAX - 2, u8::MAX)
+///     .into_elements()
+///     .collect();
+/// assert_eq!(xs, vec![253, 254, 255]);
+/// ```
+pub struct Elements<T> {
+    front: Option<T>,
+    back: Option<T>,
+}
+
+impl<T> Elements<T> {
+    #[inline(always)]
+    const fn empty() -> Self {
+        Self { front: None, back: None }
+    }
+}
+
+impl<T: Element + Ord> Elements<T> {
+    /// Build a fresh iterator from the bounds of an interval. Open bounds
+    /// step in via `try_adjacent` to land on the first/last included
+    /// element; an `Open` whose value has no neighbor in the stepping
+    /// direction (e.g. `Open(T::MAX)` on the right) collapses that
+    /// cursor to `None`.
+    fn from_bounds(lower: Option<FiniteBound<T>>, upper: Option<FiniteBound<T>>) -> Self {
+        let front = lower.and_then(|b| match b.into_raw() {
+            (BoundType::Closed, v) => Some(v),
+            (BoundType::Open, v) => v.try_adjacent(Side::Right),
+        });
+        let back = upper.and_then(|b| match b.into_raw() {
+            (BoundType::Closed, v) => Some(v),
+            (BoundType::Open, v) => v.try_adjacent(Side::Left),
+        });
+        // If front > back after open-bound stepping (e.g. `(5, 6)` discrete
+        // → no representable interior element), the next() / next_back()
+        // guards collapse to empty on first call.
+        Self { front, back }
+    }
+}
+
+impl<T: Element + Ord> Iterator for Elements<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        let current = self.front.take()?;
+        match self.back.as_ref() {
+            Some(b) if &current == b => {
+                // meeting point — yield once, exhaust both ends
+                self.back = None;
+            }
+            Some(b) if &current > b => {
+                // next_back already advanced past front; iterator is done
+                self.back = None;
+                return None;
+            }
+            _ => {
+                // advance; None propagates exhaustion at type MAX
+                self.front = current.try_adjacent(Side::Right);
+            }
+        }
+        Some(current)
+    }
+
+    // size_hint defaults to (0, None). A tighter bound for finite-bounded
+    // intervals is `Countable::count_inclusive(front, back)`, which would
+    // also unlock ExactSizeIterator. Deferred: pulling Countable into
+    // these bounds shrinks the set of types this works for. Revisit as a
+    // separate `impl<T: Countable> Elements<T>` block carrying only the
+    // tighter size_hint and ExactSizeIterator.
+}
+
+impl<T: Element + Ord> DoubleEndedIterator for Elements<T> {
+    fn next_back(&mut self) -> Option<T> {
+        let current = self.back.take()?;
+        match self.front.as_ref() {
+            Some(f) if &current == f => {
+                self.front = None;
+            }
+            Some(f) if &current < f => {
+                self.front = None;
+                return None;
+            }
+            _ => {
+                self.back = current.try_adjacent(Side::Left);
+            }
+        }
+        Some(current)
+    }
+}
+
+impl<T: Element + Ord> core::iter::FusedIterator for Elements<T> {}
+
+// ---- FiniteInterval ----
+
+impl<T: Element + Ord> IntoElementIterator for FiniteInterval<T> {
+    type Item = T;
+    type IntoIter = Elements<T>;
+
+    fn into_elements(self) -> Elements<T> {
+        match self.into_raw() {
+            None => Elements::empty(),
+            Some((lhs, rhs)) => Elements::from_bounds(Some(lhs), Some(rhs)),
+        }
+    }
+}
+
+impl<T: Element + Ord + Clone> FiniteInterval<T> {
+    /// Borrow `self` and produce an iterator over its discrete elements.
+    pub fn elements(&self) -> Elements<T> {
+        match self.view_raw() {
+            None => Elements::empty(),
+            Some((lhs, rhs)) => Elements::from_bounds(Some(lhs.clone()), Some(rhs.clone())),
+        }
+    }
+}
+
+// ---- HalfInterval ----
+
+impl<T: Element + Ord> IntoElementIterator for HalfInterval<T> {
+    type Item = T;
+    type IntoIter = Elements<T>;
+
+    fn into_elements(self) -> Elements<T> {
+        let (side, bound) = self.into_raw();
+        match side {
+            Side::Left => Elements::from_bounds(Some(bound), None),
+            Side::Right => Elements::from_bounds(None, Some(bound)),
+        }
+    }
+}
+
+impl<T: Element + Ord + Clone> HalfInterval<T> {
+    /// Borrow `self` and produce an iterator over its discrete elements.
+    pub fn elements(&self) -> Elements<T> {
+        let bound = self.finite_bound().clone();
+        match self.side() {
+            Side::Left => Elements::from_bounds(Some(bound), None),
+            Side::Right => Elements::from_bounds(None, Some(bound)),
+        }
+    }
+}
+
+// ---- EnumInterval ----
+
+impl<T: Element + Ord> IntoElementIterator for EnumInterval<T> {
+    type Item = T;
+    type IntoIter = Elements<T>;
+
+    fn into_elements(self) -> Elements<T> {
+        match self {
+            Self::Finite(inner) => inner.into_elements(),
+            Self::Half(inner) => inner.into_elements(),
+            Self::Unbounded => Elements::empty(),
+        }
+    }
+}
+
+impl<T: Element + Ord + Clone> EnumInterval<T> {
+    /// Borrow `self` and produce an iterator over its discrete elements.
+    pub fn elements(&self) -> Elements<T> {
+        match self {
+            Self::Finite(inner) => inner.elements(),
+            Self::Half(inner) => inner.elements(),
+            Self::Unbounded => Elements::empty(),
+        }
+    }
+}
+
+/// f32/f64 are not `Ord`, so `into_elements()` doesn't compile for them.
+///
+/// ```compile_fail
+/// use intervalsets_core::prelude::*;
+/// let _ = FiniteInterval::closed(0.0_f64, 1.0).into_elements();
+/// ```
+#[allow(dead_code)]
+struct ContinuousCompileFailDoctest;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::factory::FiniteFactory;
+
+    #[test]
+    fn finite_closed_walks_forward() {
+        assert!(FiniteInterval::closed(0, 4)
+            .into_elements()
+            .eq([0, 1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn finite_closed_walks_backward() {
+        assert!(FiniteInterval::closed(0, 4)
+            .into_elements()
+            .rev()
+            .eq([4, 3, 2, 1, 0]));
+    }
+
+    #[test]
+    fn finite_open_steps_in_for_discrete() {
+        assert!(EnumInterval::open(0, 5).into_elements().eq([1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn singleton_yields_once_forward() {
+        assert!(FiniteInterval::closed(7, 7).into_elements().eq([7]));
+    }
+
+    #[test]
+    fn singleton_yields_once_backward() {
+        assert!(FiniteInterval::closed(7, 7)
+            .into_elements()
+            .rev()
+            .eq([7]));
+    }
+
+    #[test]
+    fn empty_yields_nothing() {
+        let mut it = FiniteInterval::<i32>::empty().into_elements();
+        assert_eq!(it.next(), None);
+        assert_eq!(it.next_back(), None);
+    }
+
+    #[test]
+    fn unbounded_yields_nothing_either_direction() {
+        let mut fwd = EnumInterval::<i32>::Unbounded.into_elements();
+        assert_eq!(fwd.next(), None);
+
+        let mut back = EnumInterval::<i32>::Unbounded.into_elements();
+        assert_eq!(back.next_back(), None);
+    }
+
+    #[test]
+    fn left_half_bounded_walks_forward_and_terminates_at_max() {
+        // u8 max is 255; start near it so the walk terminates.
+        let iset = HalfInterval::left(FiniteBound::closed(253u8));
+        assert!(iset.into_elements().eq([253u8, 254, 255]));
+    }
+
+    #[test]
+    fn left_half_bounded_yields_nothing_in_reverse() {
+        let iset = HalfInterval::left(FiniteBound::closed(0u8));
+        assert_eq!(iset.into_elements().next_back(), None);
+    }
+
+    #[test]
+    fn right_half_bounded_walks_backward_and_terminates_at_min() {
+        let iset = HalfInterval::right(FiniteBound::closed(2u8));
+        assert!(iset.into_elements().rev().eq([2u8, 1, 0]));
+    }
+
+    #[test]
+    fn right_half_bounded_yields_nothing_forward() {
+        let iset = HalfInterval::right(FiniteBound::closed(10u8));
+        assert_eq!(iset.into_elements().next(), None);
+    }
+
+    #[test]
+    fn meeting_in_the_middle() {
+        let mut it = FiniteInterval::closed(0, 5).into_elements();
+        assert_eq!(it.next(), Some(0));
+        assert_eq!(it.next_back(), Some(5));
+        assert_eq!(it.next(), Some(1));
+        assert_eq!(it.next_back(), Some(4));
+        assert_eq!(it.next(), Some(2));
+        assert_eq!(it.next_back(), Some(3));
+        assert_eq!(it.next(), None);
+        assert_eq!(it.next_back(), None);
+    }
+
+    #[test]
+    fn meeting_at_a_single_remaining_element() {
+        // Odd length — the meeting yields the lone middle element.
+        let mut it = FiniteInterval::closed(0, 4).into_elements();
+        assert_eq!(it.next(), Some(0));
+        assert_eq!(it.next_back(), Some(4));
+        assert_eq!(it.next(), Some(1));
+        assert_eq!(it.next_back(), Some(3));
+        assert_eq!(it.next(), Some(2));
+        assert_eq!(it.next(), None);
+        assert_eq!(it.next_back(), None);
+    }
+
+    #[test]
+    fn type_max_terminates_forward_walk() {
+        assert!(FiniteInterval::closed(u8::MAX - 2, u8::MAX)
+            .into_elements()
+            .eq([253u8, 254, 255]));
+    }
+
+    #[test]
+    fn type_min_terminates_backward_walk() {
+        assert!(FiniteInterval::closed(0u8, 2)
+            .into_elements()
+            .rev()
+            .eq([2u8, 1, 0]));
+    }
+
+    #[test]
+    fn elements_borrowed_does_not_consume() {
+        let interval = FiniteInterval::closed(0, 3);
+        assert!(interval.elements().eq([0, 1, 2, 3]));
+        // Still usable.
+        assert_eq!(interval.elements().count(), 4);
+    }
+
+    #[test]
+    fn elements_borrowed_on_enum() {
+        let iv = EnumInterval::closed(10, 13);
+        assert!(iv.elements().eq([10, 11, 12, 13]));
+    }
+
+    #[test]
+    fn elements_borrowed_on_half() {
+        let iv = HalfInterval::left(FiniteBound::closed(253u8));
+        assert!(iv.elements().eq([253u8, 254, 255]));
+    }
+
+    #[test]
+    fn fused_after_exhaustion() {
+        let mut it = FiniteInterval::closed(0, 1).into_elements();
+        assert_eq!(it.next(), Some(0));
+        assert_eq!(it.next(), Some(1));
+        assert_eq!(it.next(), None);
+        // Fused — repeated calls keep returning None.
+        assert_eq!(it.next(), None);
+        assert_eq!(it.next(), None);
+        assert_eq!(it.next_back(), None);
+    }
+}

--- a/intervalsets-core/src/ops/mod.rs
+++ b/intervalsets-core/src/ops/mod.rs
@@ -62,10 +62,10 @@
 //! invariants and is not reachable from validating-API usage.
 //!
 //! Members: [`Complement`], [`Intersection`], [`Union`],
-//! [`Difference`], [`IntoFinite`], plus [`MergeConnected`] (the
-//! `Option` is a domain answer — "operands disconnected" — not an
-//! error). The bound on each impl varies; bound choice is independent
-//! of fallibility.
+//! [`Difference`], [`IntoFinite`], [`IntoElementIterator`], plus
+//! [`MergeConnected`] (the `Option` is a domain answer — "operands
+//! disconnected" — not an error). The bound on each impl varies; bound
+//! choice is independent of fallibility.
 //!
 //! ## Tier 3 — `try_*` + panicking sugar
 //!
@@ -119,6 +119,9 @@ pub use union::Union;
 
 mod finite;
 pub use finite::IntoFinite;
+
+mod elem_iter;
+pub use elem_iter::{Elements, IntoElementIterator};
 
 pub mod math;
 

--- a/intervalsets-core/src/ops/mod.rs
+++ b/intervalsets-core/src/ops/mod.rs
@@ -121,7 +121,7 @@ mod finite;
 pub use finite::IntoFinite;
 
 mod elem_iter;
-pub use elem_iter::{Elements, IntoElementIterator};
+pub use elem_iter::{DisjointElements, Elements, IntoElementIterator};
 
 pub mod math;
 

--- a/intervalsets/src/ops/elem_iter.rs
+++ b/intervalsets/src/ops/elem_iter.rs
@@ -89,6 +89,25 @@ impl<T: Element + Ord> Iterator for SetElements<T> {
             return None;
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // Each pending interval is non-empty (IntervalSet invariant), so
+        // contributes at least 1 element. Front and back walkers delegate
+        // to Elements<T>::size_hint — (0, None) today, but a tighter hint
+        // (via Countable, deferred) is picked up for free.
+        let (fl, fu) = self.front.as_ref().map_or((0, Some(0)), Iterator::size_hint);
+        let (bl, bu) = self.back.as_ref().map_or((0, Some(0)), Iterator::size_hint);
+        let pending = self.intervals.len();
+        let lower = fl.saturating_add(bl).saturating_add(pending);
+        // Upper is known only if every pending piece's count is known —
+        // which today requires Countable, so we conservatively return
+        // None whenever any piece remains.
+        let upper = match (fu, bu) {
+            (Some(a), Some(b)) if pending == 0 => a.checked_add(b),
+            _ => None,
+        };
+        (lower, upper)
+    }
 }
 
 impl<T: Element + Ord> DoubleEndedIterator for SetElements<T> {
@@ -307,6 +326,40 @@ mod tests {
         let collected: Vec<u8> =
             set.into_elements().rev().take(5).collect();
         assert_eq!(collected, vec![101, 100, 2, 1, 0]);
+    }
+
+    // ---- size_hint ----
+
+    #[test]
+    fn set_elements_size_hint_empty_is_exact_zero() {
+        let set = IntervalSet::<i32>::empty();
+        let it = set.into_elements();
+        assert_eq!(it.size_hint(), (0, Some(0)));
+    }
+
+    #[test]
+    fn set_elements_size_hint_lower_bound_counts_pending_pieces() {
+        // Two unconsumed pieces; each contributes ≥1 by invariant.
+        // Upper is unknown without Countable.
+        let set = IntervalSet::new([
+            Interval::closed(0, 2),
+            Interval::closed(10, 12),
+        ]);
+        let it = set.into_elements();
+        let (lower, upper) = it.size_hint();
+        assert_eq!(lower, 2);
+        assert!(upper.is_none());
+    }
+
+    #[test]
+    fn set_elements_size_hint_consumed_is_exact_zero() {
+        let set = IntervalSet::new([
+            Interval::closed(0, 1),
+            Interval::closed(10, 11),
+        ]);
+        let mut it = set.into_elements();
+        for _ in &mut it {}
+        assert_eq!(it.size_hint(), (0, Some(0)));
     }
 
     #[test]

--- a/intervalsets/src/ops/elem_iter.rs
+++ b/intervalsets/src/ops/elem_iter.rs
@@ -1,0 +1,170 @@
+//! Element-wise iteration for [`Interval`] and [`IntervalSet`].
+//!
+//! Re-exports the [`IntoElementIterator`] trait and [`Elements`] iterator
+//! from [`intervalsets_core::ops::elem_iter`], and adds outer-crate impls.
+//!
+//! `IntervalSet` already implements [`IntoIterator`] for **interval-wise**
+//! reading (yielding `Interval<T>` pieces). [`IntoElementIterator`] is
+//! the separate, named entry point for **element-wise** reading
+//! (yielding `T`), so the two don't compete.
+
+pub use intervalsets_core::ops::{Elements, IntoElementIterator};
+
+use crate::numeric::Element;
+use crate::{Interval, IntervalSet};
+
+// ---- Interval (newtype around EnumInterval) ----
+
+impl<T: Element + Ord> IntoElementIterator for Interval<T> {
+    type Item = T;
+    type IntoIter = Elements<T>;
+
+    fn into_elements(self) -> Elements<T> {
+        self.0.into_elements()
+    }
+}
+
+impl<T: Element + Ord + Clone> Interval<T> {
+    /// Borrow `self` and produce an iterator over its discrete elements.
+    pub fn elements(&self) -> Elements<T> {
+        self.0.elements()
+    }
+}
+
+// ---- IntervalSet ----
+
+/// Iterator over the discrete element values of an [`IntervalSet`].
+///
+/// Walks each interval piece in ascending order via [`Elements`], then
+/// advances to the next piece. Implements [`Iterator`] and
+/// [`core::iter::FusedIterator`].
+///
+/// Constructed via [`IntoElementIterator::into_elements`] (consume) or
+/// [`IntervalSet::elements`] (borrow).
+///
+/// # Examples
+///
+/// ```
+/// use intervalsets::prelude::*;
+///
+/// let set = IntervalSet::new([Interval::closed(0, 2), Interval::closed(10, 12)]);
+/// let xs: Vec<i32> = set.into_elements().collect();
+/// assert_eq!(xs, vec![0, 1, 2, 10, 11, 12]);
+/// ```
+pub struct SetElements<T> {
+    intervals: std::vec::IntoIter<Interval<T>>,
+    current: Option<Elements<T>>,
+}
+
+impl<T: Element + Ord> Iterator for SetElements<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        loop {
+            if let Some(it) = self.current.as_mut() {
+                if let Some(v) = it.next() {
+                    return Some(v);
+                }
+            }
+            // Current piece exhausted; advance to the next one.
+            let next_interval = self.intervals.next()?;
+            self.current = Some(next_interval.into_elements());
+        }
+    }
+}
+
+impl<T: Element + Ord> core::iter::FusedIterator for SetElements<T> {}
+
+impl<T: Element + Ord> IntoElementIterator for IntervalSet<T> {
+    type Item = T;
+    type IntoIter = SetElements<T>;
+
+    fn into_elements(self) -> SetElements<T> {
+        SetElements {
+            intervals: self.into_raw().into_iter(),
+            current: None,
+        }
+    }
+}
+
+impl<T: Element + Ord + Clone> IntervalSet<T> {
+    /// Borrow `self` and produce an iterator over its discrete elements.
+    ///
+    /// Walks each interval piece in ascending order, yielding every
+    /// element along the way.
+    pub fn elements(&self) -> SetElements<T> {
+        // Clone the slice of intervals so the iterator is owned (no
+        // lifetime parameter). Per-interval clones are O(1) bounds; the
+        // element walk that follows dominates this cost.
+        SetElements {
+            intervals: self.slice().to_vec().into_iter(),
+            current: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::factory::traits::*;
+
+    #[test]
+    fn interval_into_elements() {
+        assert!(Interval::closed(0, 4).into_elements().eq([0, 1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn interval_elements_borrow() {
+        let iv = Interval::closed(2u8, 5);
+        assert!(iv.elements().eq([2u8, 3, 4, 5]));
+        // Still usable.
+        assert_eq!(iv.elements().count(), 4);
+    }
+
+    #[test]
+    fn interval_set_into_elements_multi_piece() {
+        let set = IntervalSet::new([
+            Interval::closed(0, 2),
+            Interval::closed(10, 12),
+        ]);
+        let collected: Vec<i32> = set.into_elements().collect();
+        assert_eq!(collected, vec![0, 1, 2, 10, 11, 12]);
+    }
+
+    #[test]
+    fn interval_set_elements_borrow() {
+        let set = IntervalSet::new([
+            Interval::closed(0u8, 1),
+            Interval::closed(253, 255),
+        ]);
+        let collected: Vec<u8> = set.elements().collect();
+        assert_eq!(collected, vec![0, 1, 253, 254, 255]);
+        // Still usable.
+        let again: Vec<u8> = set.elements().collect();
+        assert_eq!(again, vec![0, 1, 253, 254, 255]);
+    }
+
+    #[test]
+    fn interval_set_empty_yields_nothing() {
+        let set = IntervalSet::<i32>::empty();
+        assert_eq!(set.into_elements().next(), None);
+    }
+
+    #[test]
+    fn interval_set_singleton_piece_yields_once() {
+        let set = IntervalSet::new([Interval::closed(7, 7)]);
+        let collected: Vec<i32> = set.into_elements().collect();
+        assert_eq!(collected, vec![7]);
+    }
+
+    #[test]
+    fn interval_set_with_half_bounded_walks_until_max() {
+        // Right-most piece is half-bounded → continues to type MAX.
+        let set = IntervalSet::new([
+            Interval::closed(0u8, 1),
+            Interval::closed_unbound(254),
+        ]);
+        let collected: Vec<u8> = set.into_elements().collect();
+        assert_eq!(collected, vec![0, 1, 254, 255]);
+    }
+}

--- a/intervalsets/src/ops/elem_iter.rs
+++ b/intervalsets/src/ops/elem_iter.rs
@@ -8,7 +8,7 @@
 //! the separate, named entry point for **element-wise** reading
 //! (yielding `T`), so the two don't compete.
 
-pub use intervalsets_core::ops::{Elements, IntoElementIterator};
+pub use intervalsets_core::ops::{DisjointElements, Elements, IntoElementIterator};
 
 use crate::numeric::Element;
 use crate::{Interval, IntervalSet};

--- a/intervalsets/src/ops/elem_iter.rs
+++ b/intervalsets/src/ops/elem_iter.rs
@@ -35,9 +35,11 @@ impl<T: Element + Ord + Clone> Interval<T> {
 
 /// Iterator over the discrete element values of an [`IntervalSet`].
 ///
-/// Walks each interval piece in ascending order via [`Elements`], then
-/// advances to the next piece. Implements [`Iterator`] and
-/// [`core::iter::FusedIterator`].
+/// Walks each interval piece in order via [`Elements`], advancing through
+/// pieces from either end. Implements [`Iterator`],
+/// [`DoubleEndedIterator`], and [`core::iter::FusedIterator`], so
+/// `.rev()`, mixed forward/backward walks, and the usual combinators all
+/// work.
 ///
 /// Constructed via [`IntoElementIterator::into_elements`] (consume) or
 /// [`IntervalSet::elements`] (borrow).
@@ -48,12 +50,16 @@ impl<T: Element + Ord + Clone> Interval<T> {
 /// use intervalsets::prelude::*;
 ///
 /// let set = IntervalSet::new([Interval::closed(0, 2), Interval::closed(10, 12)]);
-/// let xs: Vec<i32> = set.into_elements().collect();
+/// let xs: Vec<i32> = set.clone().into_elements().collect();
 /// assert_eq!(xs, vec![0, 1, 2, 10, 11, 12]);
+///
+/// let xs: Vec<i32> = set.into_elements().rev().collect();
+/// assert_eq!(xs, vec![12, 11, 10, 2, 1, 0]);
 /// ```
 pub struct SetElements<T> {
     intervals: std::vec::IntoIter<Interval<T>>,
-    current: Option<Elements<T>>,
+    front: Option<Elements<T>>,
+    back: Option<Elements<T>>,
 }
 
 impl<T: Element + Ord> Iterator for SetElements<T> {
@@ -61,14 +67,53 @@ impl<T: Element + Ord> Iterator for SetElements<T> {
 
     fn next(&mut self) -> Option<T> {
         loop {
-            if let Some(it) = self.current.as_mut() {
+            // 1. The forward walker has more in its current piece.
+            if let Some(it) = self.front.as_mut() {
                 if let Some(v) = it.next() {
                     return Some(v);
                 }
+                self.front = None;
             }
-            // Current piece exhausted; advance to the next one.
-            let next_interval = self.intervals.next()?;
-            self.current = Some(next_interval.into_elements());
+            // 2. Pull the next-leftmost piece into the forward walker.
+            if let Some(piece) = self.intervals.next() {
+                self.front = Some(piece.into_elements());
+                continue;
+            }
+            // 3. No pieces between cursors. The back walker is in the
+            //    last remaining piece; serve forward calls from it too.
+            //    Elements<T> is itself DoubleEndedIterator, so meeting
+            //    in the middle is handled there.
+            if let Some(it) = self.back.as_mut() {
+                if let Some(v) = it.next() {
+                    return Some(v);
+                }
+                self.back = None;
+            }
+            return None;
+        }
+    }
+}
+
+impl<T: Element + Ord> DoubleEndedIterator for SetElements<T> {
+    fn next_back(&mut self) -> Option<T> {
+        loop {
+            if let Some(it) = self.back.as_mut() {
+                if let Some(v) = it.next_back() {
+                    return Some(v);
+                }
+                self.back = None;
+            }
+            if let Some(piece) = self.intervals.next_back() {
+                self.back = Some(piece.into_elements());
+                continue;
+            }
+            if let Some(it) = self.front.as_mut() {
+                if let Some(v) = it.next_back() {
+                    return Some(v);
+                }
+                self.front = None;
+            }
+            return None;
         }
     }
 }
@@ -82,7 +127,8 @@ impl<T: Element + Ord> IntoElementIterator for IntervalSet<T> {
     fn into_elements(self) -> SetElements<T> {
         SetElements {
             intervals: self.into_raw().into_iter(),
-            current: None,
+            front: None,
+            back: None,
         }
     }
 }
@@ -90,15 +136,16 @@ impl<T: Element + Ord> IntoElementIterator for IntervalSet<T> {
 impl<T: Element + Ord + Clone> IntervalSet<T> {
     /// Borrow `self` and produce an iterator over its discrete elements.
     ///
-    /// Walks each interval piece in ascending order, yielding every
-    /// element along the way.
+    /// Walks each interval piece in order, yielding every element along
+    /// the way. The returned iterator is double-ended.
     pub fn elements(&self) -> SetElements<T> {
         // Clone the slice of intervals so the iterator is owned (no
         // lifetime parameter). Per-interval clones are O(1) bounds; the
         // element walk that follows dominates this cost.
         SetElements {
             intervals: self.slice().to_vec().into_iter(),
-            current: None,
+            front: None,
+            back: None,
         }
     }
 }
@@ -166,5 +213,115 @@ mod tests {
         ]);
         let collected: Vec<u8> = set.into_elements().collect();
         assert_eq!(collected, vec![0, 1, 254, 255]);
+    }
+
+    // ---- DoubleEndedIterator coverage ----
+
+    #[test]
+    fn interval_set_into_elements_reversed() {
+        let set = IntervalSet::new([
+            Interval::closed(0, 2),
+            Interval::closed(10, 12),
+        ]);
+        let collected: Vec<i32> = set.into_elements().rev().collect();
+        assert_eq!(collected, vec![12, 11, 10, 2, 1, 0]);
+    }
+
+    #[test]
+    fn interval_set_next_back_only() {
+        let set = IntervalSet::new([
+            Interval::closed(0, 1),
+            Interval::closed(10, 11),
+        ]);
+        let mut it = set.into_elements();
+        assert_eq!(it.next_back(), Some(11));
+        assert_eq!(it.next_back(), Some(10));
+        assert_eq!(it.next_back(), Some(1));
+        assert_eq!(it.next_back(), Some(0));
+        assert_eq!(it.next_back(), None);
+        assert_eq!(it.next(), None);
+    }
+
+    #[test]
+    fn interval_set_meeting_across_three_singletons() {
+        // Three single-element pieces; mixed direction walks should yield
+        // every element exactly once.
+        let set = IntervalSet::new([
+            Interval::closed(0, 0),
+            Interval::closed(5, 5),
+            Interval::closed(10, 10),
+        ]);
+        let mut it = set.into_elements();
+        assert_eq!(it.next_back(), Some(10));
+        assert_eq!(it.next(), Some(0));
+        assert_eq!(it.next(), Some(5));
+        assert_eq!(it.next(), None);
+        assert_eq!(it.next_back(), None);
+    }
+
+    #[test]
+    fn interval_set_meeting_inside_one_piece() {
+        // Two pieces; consume one from front, then one from back, then
+        // both walkers converge on the remaining elements of one piece.
+        let set = IntervalSet::new([
+            Interval::closed(0, 1),
+            Interval::closed(10, 14),
+        ]);
+        let mut it = set.into_elements();
+        assert_eq!(it.next(), Some(0));
+        assert_eq!(it.next(), Some(1));
+        assert_eq!(it.next_back(), Some(14));
+        assert_eq!(it.next(), Some(10));
+        assert_eq!(it.next_back(), Some(13));
+        assert_eq!(it.next(), Some(11));
+        assert_eq!(it.next_back(), Some(12));
+        assert_eq!(it.next(), None);
+        assert_eq!(it.next_back(), None);
+    }
+
+    #[test]
+    fn interval_set_single_piece_mixed_walk() {
+        // One piece, mixed directions inside it.
+        let set = IntervalSet::new([Interval::closed(0, 4)]);
+        let mut it = set.into_elements();
+        assert_eq!(it.next(), Some(0));
+        assert_eq!(it.next_back(), Some(4));
+        assert_eq!(it.next(), Some(1));
+        assert_eq!(it.next_back(), Some(3));
+        assert_eq!(it.next(), Some(2));
+        assert_eq!(it.next(), None);
+        assert_eq!(it.next_back(), None);
+    }
+
+    #[test]
+    fn interval_set_empty_yields_nothing_in_reverse() {
+        let set = IntervalSet::<i32>::empty();
+        assert_eq!(set.into_elements().next_back(), None);
+    }
+
+    #[test]
+    fn interval_set_left_half_bounded_in_reverse_walks_to_min() {
+        // Leftmost piece is `(-∞, 2]`; reverse iteration should walk it
+        // down to type MIN.
+        let set = IntervalSet::new([
+            Interval::unbound_closed(2u8),
+            Interval::closed(100, 101),
+        ]);
+        let collected: Vec<u8> =
+            set.into_elements().rev().take(5).collect();
+        assert_eq!(collected, vec![101, 100, 2, 1, 0]);
+    }
+
+    #[test]
+    fn interval_set_borrow_reverse() {
+        let set = IntervalSet::new([
+            Interval::closed(0u8, 2),
+            Interval::closed(10, 11),
+        ]);
+        let collected: Vec<u8> = set.elements().rev().collect();
+        assert_eq!(collected, vec![11, 10, 2, 1, 0]);
+        // Still usable.
+        let again: Vec<u8> = set.elements().collect();
+        assert_eq!(again, vec![0, 1, 2, 10, 11]);
     }
 }

--- a/intervalsets/src/ops/elem_iter.rs
+++ b/intervalsets/src/ops/elem_iter.rs
@@ -67,22 +67,19 @@ impl<T: Element + Ord> Iterator for SetElements<T> {
 
     fn next(&mut self) -> Option<T> {
         loop {
-            // 1. The forward walker has more in its current piece.
             if let Some(it) = self.front.as_mut() {
                 if let Some(v) = it.next() {
                     return Some(v);
                 }
                 self.front = None;
             }
-            // 2. Pull the next-leftmost piece into the forward walker.
             if let Some(piece) = self.intervals.next() {
                 self.front = Some(piece.into_elements());
                 continue;
             }
-            // 3. No pieces between cursors. The back walker is in the
-            //    last remaining piece; serve forward calls from it too.
-            //    Elements<T> is itself DoubleEndedIterator, so meeting
-            //    in the middle is handled there.
+            // No pieces left between cursors; the back walker is in the
+            // final remaining piece. Elements<T> is DoubleEndedIterator,
+            // so it handles meeting-in-the-middle for the shared piece.
             if let Some(it) = self.back.as_mut() {
                 if let Some(v) = it.next() {
                     return Some(v);

--- a/intervalsets/src/ops/mod.rs
+++ b/intervalsets/src/ops/mod.rs
@@ -49,5 +49,8 @@ pub use rebound::Rebound;
 mod finite;
 pub use finite::IntoFinite;
 
+mod elem_iter;
+pub use elem_iter::{Elements, IntoElementIterator, SetElements};
+
 mod math;
 pub use math::{TryAdd, TryDiv, TryMul, TrySub};

--- a/intervalsets/src/ops/mod.rs
+++ b/intervalsets/src/ops/mod.rs
@@ -50,7 +50,7 @@ mod finite;
 pub use finite::IntoFinite;
 
 mod elem_iter;
-pub use elem_iter::{Elements, IntoElementIterator, SetElements};
+pub use elem_iter::{DisjointElements, Elements, IntoElementIterator, SetElements};
 
 mod math;
 pub use math::{TryAdd, TryDiv, TryMul, TrySub};


### PR DESCRIPTION
## Summary

Adds element-wise iteration over discrete intervals and interval sets,
distinct from existing interval-wise iteration.

- New `IntoElementIterator` trait in `core::ops::elem_iter`. Implemented
  on owned set types only; mirrors std's `into_iter()` / `iter()` split
  by pairing it with an inherent `.elements()` method for borrowed entry.
  Named separately from `IntoIterator` so `IntervalSet`'s interval-wise
  reading isn't displaced.
- New `Elements<T>` iterator (single-interval). Implements `Iterator`,
  `DoubleEndedIterator`, and `FusedIterator`. Two-`Option<T>`-cursor
  design handles half-bounded and unbounded shapes naturally — a `None`
  cursor is "this direction yields nothing" without panic or branch.
- New `SetElements<T>` iterator (multi-piece, outer crate). Walks each
  `Interval` piece via `Elements`. Also implements `DoubleEndedIterator`,
  meeting cleanly in the middle by leaning on `Elements`'s own
  double-endedness for the final shared piece.
- Discreteness gate is `T: Element + Ord` — standard ecosystem trait;
  excludes `f32`/`f64` mechanically. No `Countable` dependency.

## Why this shape

`IntervalSet` has two natural iteration semantics — interval-wise
(yielding pieces) and element-wise (yielding `T`). `IntoIterator` is
the natural home for the interval-wise reading, so element-wise needs
its own named trait. Keeping advancement on `Element::try_adjacent`
(which returns owned `T`) means no `Clone` bound on the consuming path;
`Clone` only appears on the borrowed `.elements(&self)` methods.