### PR TITLE
ci: auto-skip changelog gate for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,16 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    # Dependabot does not read `rust-version` — bumps that violate MSRV
+    # land here unless explicitly ignored. The `msrv-check` CI job catches
+    # them; when one trips, close the PR and pin the offending range under
+    # `ignore:` below. Re-audit every time MSRV is raised — see
+    # CONTRIBUTING.md "Dependency updates and MSRV".
+    #
+    # Example:
+    #   ignore:
+    #     - dependency-name: "some-crate"
+    #       versions: [">= 2.0.0"]  # requires rustc >= 1.NN
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/dependabot-label.yml
+++ b/.github/workflows/dependabot-label.yml
@@ -1,0 +1,28 @@
+name: Dependabot auto-label
+
+# Auto-applies `skip-changelog` to dependabot PRs so they don't trip the
+# changelog-enforcement gate. If a runtime-dep bump turns out to be
+# user-visible, the reviewer drops the label and adds a manual entry
+# before merging.
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['skip-changelog'],
+            });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,22 @@ toolchain" case gracefully). They're marked as `build:` in PR titles, trigger
 a **minor** version bump, are called out in the changelog, and are tested
 in CI via the `msrv-check` job.
 
+### Dependency updates and MSRV
+
+Dependabot does not read `rust-version` — it will happily open PRs that bump a
+dependency past our MSRV. The `msrv-check` CI job is the backstop: such PRs
+fail and are not mergeable.
+
+When that happens:
+
+1. Close the dependabot PR.
+2. Add the offending range to the `ignore:` block in `.github/dependabot.yml`,
+   with an inline comment recording the rustc version the new release requires.
+
+**Whenever MSRV is raised**, audit the `ignore:` block in the same PR and remove
+or relax entries that the new MSRV makes valid again. Otherwise we silently
+fall behind on dependencies that are now in range.
+
 ## Versioning between crates
 
 `intervalsets` and `intervalsets-core` ship in **lockstep** — both crates


### PR DESCRIPTION
Adds a workflow that labels every dependabot PR with `skip-changelog` so routine version bumps don't trip the changelog-enforcement gate. Documents the MSRV-vs-dependabot interaction in CONTRIBUTING.md and reserves an `ignore:` slot in dependabot.yml for pinning bumps that exceed our MSRV.

This is purely a housekeeping PR to streamline the dependabot CI procces and should have no bearing on the library or build.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Performance (`perf:`)
- [ ] Documentation (`docs:`)
- [ ] Tests only (`test:`)
- [x] Tooling / chore (`chore:`)
- [ ] Breaking change (append `!` to type)

